### PR TITLE
Many fixes

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,14 +7,8 @@ Type=simple
 User=__APP__
 Group=__APP__
 
-Environment="APP_BASE_URL=https://__DOMAIN__"
-Environment="APP_PORT=__PORT__"
-Environment="DB_CLIENT=pg"
-Environment="POSTGRES_PASSWORD=__DB_PWD__"
-Environment="POSTGRES_DATABASE=__DB_NAME__"
-Environment="POSTGRES_USER=__DB_USER__"
-Environment="POSTGRES_PORT=5432"
-Environment="POSTGRES_HOST=localhost"
+Environment="__YNH_NODE_LOAD_PATH__"
+EnvironmentFile=__INSTALL_DIR__/.env
 
 WorkingDirectory=__INSTALL_DIR__/
 ExecStart=/usr/bin/yarn __INSTALL_DIR__/packages/server start

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,9 +1,8 @@
 Now login to Joplin
+ - Url: https://__DOMAIN____PATH__
+ - Email: __ADMIN_MAIL__
+ - Password: __ADMIN_PASS__
 
-- Url: https://**DOMAIN\_\_**PATH\_\_
-- Email: **ADMIN_MAIL**
-- Password: **ADMIN_PASS**
-
-Then you may change the default password at this page: https://**DOMAIN\_\_**PATH\_\_/admin/users
+Then you may change the default password at this page: https://__DOMAIN____PATH__/admin/users
 
 Then download one of these Joplin apps and configure the synchronisation with your server: https://joplinapp.org/help/install/

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,4 +1,6 @@
-Default credentials:
+Now login to Joplin
+ - Url: https://__DOMAIN____PATH__
+ - Email: admin@localhost
+ - Password: __ADMIN_PASS__
 
-Email: admin@localhost
-Password: admin
+Then you may change the default email and password at this page: https://joplin.local/admin/users

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,6 +1,9 @@
 Now login to Joplin
- - Url: https://__DOMAIN____PATH__
- - Email: admin@localhost
- - Password: __ADMIN_PASS__
 
-Then you may change the default email and password at this page: https://joplin.local/admin/users
+- Url: https://**DOMAIN\_\_**PATH\_\_
+- Email: **ADMIN_MAIL**
+- Password: **ADMIN_PASS**
+
+Then you may change the default password at this page: https://**DOMAIN\_\_**PATH\_\_/admin/users
+
+Then download one of these Joplin apps and configure the synchronisation with your server: https://joplinapp.org/help/install/

--- a/manifest.toml
+++ b/manifest.toml
@@ -38,6 +38,9 @@ ram.runtime = "50M"
     type = "group"
     default = "visitors"
 
+    [install.admin]
+    type = "user"
+
 [resources]
 
     [resources.sources]

--- a/manifest.toml
+++ b/manifest.toml
@@ -63,7 +63,7 @@ ram.runtime = "50M"
     main.default = 22300
 
     [resources.apt]
-    packages = "postgresql, postgresql-client"
+    packages = "postgresql, postgresql-client, python3-bcrypt"
     extras.yarn.repo = "deb https://dl.yarnpkg.com/debian/ stable main"
     extras.yarn.key = "https://dl.yarnpkg.com/debian/pubkey.gpg"
     extras.yarn.packages = "yarn"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,6 +10,11 @@ nodejs_version=18
 # PERSONAL HELPERS
 #=================================================
 
+function bcrypt_password() {
+  echo -n "$1" | \
+    python3 -c "import bcrypt; import sys; print(bcrypt.hashpw(bytes(sys.stdin.read(), 'ascii'), bcrypt.gensalt(rounds=10)).decode('ascii'))"
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/backup
+++ b/scripts/backup
@@ -34,7 +34,7 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_backup --src_path="/etc/systemd/system/$app.service"
 
 #=================================================
-# BACKUP THE MYSQL DATABASE
+# BACKUP THE PostgreSQL DATABASE
 #=================================================
 ynh_print_info --message="Backing up the PostgreSQL database..."
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -25,7 +25,11 @@ ynh_script_progression --message="Updating NGINX web server configuration..." --
 
 ynh_change_url_nginx_config
 
+ynh_use_nodejs
+
 ynh_add_systemd_config
+
+ynh_add_config --template=".env" --destination="$install_dir/.env"
 
 #=================================================
 # GENERIC FINALISATION

--- a/scripts/install
+++ b/scripts/install
@@ -88,7 +88,6 @@ ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --l
 #=================================================
 # CHANGING DEFAULT ADMIN PASSWORD
 #=================================================
-
 ynh_script_progression --message="Changing default admin password..." --weight=1
 
 hashed_pwd=$(bcrypt_password "$admin_pass")

--- a/scripts/install
+++ b/scripts/install
@@ -67,9 +67,10 @@ chown $app:$app "$install_dir/.env"
 #=================================================
 ynh_script_progression --message="Building $app..." --weight=10
 
-pushd $install_dir
+pushd $install_dir/packages/server
  	ynh_use_nodejs
 	sudo -u $app env $ynh_node_load_PATH BUILD_SEQUENCIAL=1 yarn install --inline-builds
+	sudo -u $app env $ynh_node_load_PATH yarn build
 	sudo -u $app env $ynh_node_load_PATH yarn cache clean
 	ynh_secure_remove .yarn/berry
 popd

--- a/scripts/install
+++ b/scripts/install
@@ -9,6 +9,9 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
+admin_pass=$(ynh_string_random --length=24)
+ynh_app_setting_set --app=$app --key=admin_pass --value=$admin_pass
+
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
@@ -74,7 +77,18 @@ popd
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --log_path="systemd"
+ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Starting services..."
+
+#=================================================
+# CHANGING DEFAULT ADMIN PASSWORD
+#=================================================
+
+ynh_script_progression --message="Changing default admin password..." --weight=1
+
+hashed_pwd=$(bcrypt_password "$admin_pass")
+
+ynh_psql_connect_as --user="$db_user" --password="$db_pwd" --database="$db_name" <<< \
+  "UPDATE users SET password='$hashed_pwd' WHERE email='admin@localhost'"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -10,7 +10,12 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 admin_pass=$(ynh_string_random --length=24)
+admin_mail=$(ynh_user_get_info --username=$admin --key="mail")
+admin_name=$(ynh_user_get_info --username=$admin --key="fullname")
+
+# Store these values even if we don't need them, so they are printed in the post-install message
 ynh_app_setting_set --app=$app --key=admin_pass --value=$admin_pass
+ynh_app_setting_set --app=$app --key=admin_mail --value=$admin_mail
 
 #=================================================
 # INSTALL DEPENDENCIES
@@ -60,7 +65,7 @@ chown $app:$app "$install_dir/.env"
 #=================================================
 # INSTALL JOPLIN
 #=================================================
-ynh_script_progression --message="Installing $app..." --weight=10
+ynh_script_progression --message="Building $app..." --weight=10
 
 pushd $install_dir
  	ynh_use_nodejs
@@ -87,8 +92,11 @@ ynh_script_progression --message="Changing default admin password..." --weight=1
 
 hashed_pwd=$(bcrypt_password "$admin_pass")
 
-ynh_psql_connect_as --user="$db_user" --password="$db_pwd" --database="$db_name" <<< \
-  "UPDATE users SET password='$hashed_pwd' WHERE email='admin@localhost'"
+ynh_psql_connect_as --user="$db_user" --password="$db_pwd" --database="$db_name" <<< "
+  UPDATE users
+  SET password='$hashed_pwd', email='$admin_mail', full_name='$admin_name'
+  WHERE email='admin@localhost'
+"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -20,7 +20,7 @@ ynh_restore_file --origin_path="$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================
-# RESTORE THE MYSQL DATABASE
+# RESTORE THE PostgreSQL DATABASE
 #=================================================
 ynh_script_progression --message="Restoring the PostgreSQL database..." --weight=1
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -49,11 +49,12 @@ ynh_exec_warn_less ynh_install_nodejs --nodejs_version=$nodejs_version
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
   ynh_script_progression --message="Building $app..." --weight=10
-  pushd $install_dir
+  pushd $install_dir/packages/server
     ynh_use_nodejs
     sudo -u $app env $ynh_node_load_PATH BUILD_SEQUENCIAL=1 yarn install --inline-builds
-    # sudo -u $app env $ynh_node_load_PATH yarn cache clean
-    # ynh_secure_remove .yarn/berry
+    sudo -u $app env $ynh_node_load_PATH yarn build
+    sudo -u $app env $ynh_node_load_PATH yarn cache clean
+    ynh_secure_remove .yarn/berry
   popd
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -43,6 +43,21 @@ ynh_script_progression --message="Upgrading dependencies..." --weight=5
 ynh_exec_warn_less ynh_install_nodejs --nodejs_version=$nodejs_version
 
 #=================================================
+# BUILD
+#=================================================
+
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+  ynh_script_progression --message="Building $app..." --weight=10
+  pushd $install_dir
+    ynh_use_nodejs
+    sudo -u $app env $ynh_node_load_PATH BUILD_SEQUENCIAL=1 yarn install --inline-builds
+    # sudo -u $app env $ynh_node_load_PATH yarn cache clean
+    # ynh_secure_remove .yarn/berry
+  popd
+fi
+
+#=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
 #=================================================
 ynh_script_progression --message="Upgrading system configurations related to $app..." --weight=1


### PR DESCRIPTION
# Problem
1. The default password is obvious and can be dangerous if the administrator installs the app and forget to change it (may happen for many reasons).
2. The upgrade does not rebuild the app
3. The startup does not work
4. The URL change does not work

# Solution 
1. Instead we generate a strong one and print it after the login, s/he is then free to change it or to keep it.
2. Rebuild the app when upgrading
3. Add NodeJS PATH in env variables in systemd unit file
4. Add `ynh_use_nodejs` instruction in `change_url` so the `ynh_node_load_path` variable is set