### PR TITLE
Full replace sources on update

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd"
 ynh_script_progression --message="Upgrading source files..." --weight=1
 
 # Download, check integrity, uncompress and patch the source from manifest.toml
-ynh_setup_source --dest_dir="$install_dir" --keep=".env"
+ynh_setup_source --dest_dir="$install_dir" --keep=".env" --full_replace=1
 
 chown -R $app:www-data "$install_dir"
 

--- a/tests.toml
+++ b/tests.toml
@@ -9,3 +9,4 @@ test_format = 1.0
     # ------------
 
     exclude = ["install.subdir"]
+    test_upgrade_from.cef7030e.name = "Upgrade from 3.1.19"


### PR DESCRIPTION
As per [this log](https://paste.yunohost.org/raw/qezojojewe) `node_modules` may be in stale state. Remove old sources prior to installation upon upgrading.